### PR TITLE
Added type to DataFrame.rename mapper

### DIFF
--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -2754,14 +2754,18 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
      * 
      */
     rename(
-        mapper: any,
+        mapper: {
+            [index: string | number]: string | number
+        },
         options?: {
             axis?: 0 | 1
             inplace?: boolean
         }
     ): DataFrame
-    rename(
-        mapper: any,
+    rename(  
+        mapper: {
+            [index: string | number]: string | number
+        },
         options?: {
             axis?: 0 | 1
             inplace?: boolean
@@ -2777,8 +2781,9 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
             const colsAdded: string[] = [];
             const newColumns = this.columns.map(col => {
                 if (mapper[col] !== undefined) {
-                    colsAdded.push(mapper[col]);
-                    return mapper[col]
+                    const newCol = `${mapper[col]}`;
+                    colsAdded.push(newCol);
+                    return newCol;
                 } else {
                     return col
                 }


### PR DESCRIPTION
Fixes issue #345 

Makes the DataFrame.rename `mapper` arg have a type of:

```
{
    [index: string | number]: string | number
}
```
instead of any. Even though the `options` arg can still be mistaken as the mapper arg, between the previous `options` arg with the mapper option inside it and the current system where the mapper option is outside, the difference should be enough that Typescript would be able to warn about this new change when migrating to version 1.0.0.