### PR TITLE
Update io.json.ts

### DIFF
--- a/src/danfojs-base/io/node/io.json.ts
+++ b/src/danfojs-base/io/node/io.json.ts
@@ -145,7 +145,7 @@ const $toJSON = (df: NDframe | DataFrame | Series, options?: JsonOutputOptionsNo
 
     if (df.$isSeries) {
         const obj: { [key: string]: ArrayType1D } = {};
-        obj[df.columns[0]] = df.values as ArrayType1D;
+        obj = Object.fromEntries(df.index.map((e, i) => [e, df.values[i]]));
         if (filePath) {
             if (!filePath.endsWith(".json")) {
                 filePath = filePath + ".json"


### PR DESCRIPTION
1. toJSON() only returned values of a Series and not the index
2. the values were nested unnecessarily in a dictionary. Thus changing obj[df.columns[0]] to obj