### PR TITLE
Fix bug in groupby checking wrong colDtype

### DIFF
--- a/src/danfojs-base/aggregators/groupby.ts
+++ b/src/danfojs-base/aggregators/groupby.ts
@@ -262,7 +262,8 @@ export default class Groupby {
         let colName = groupColNames[colKey]
         let colIndex = this.columnName.indexOf(colName)
         let colDtype = this.colDtype[colIndex]
-        if (colDtype === "string") throw new Error(`Can't perform math operation on column ${colName}`)
+        let operationVal = (typeof operation === "string") ? operation : operation[colName]
+        if (colDtype === "string" && operationVal !== "count") throw new Error(`Can't perform math operation on column ${colName}`)
 
         if (typeof operation === "string") {
           let colName2 = `${colName}_${operation}`

--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -3162,9 +3162,7 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
     groupby(col: Array<string>): Groupby {
         const columns = this.columns
         const colIndex = col.map((val) => columns.indexOf(val))
-        const colDtype = this.dtypes.filter((val, index) => {
-            return colIndex.includes(index)
-        })
+        const colDtype = this.dtypes
 
         return new Groupby(
             col,

--- a/src/danfojs-browser/tests/aggregators/groupby.test.js
+++ b/src/danfojs-browser/tests/aggregators/groupby.test.js
@@ -353,4 +353,19 @@ describe("groupby", function () {
     ];
     assert.deepEqual(group_df.size().values, rslt);
   });
+  it("issue 396: fix groupby when first column is int", function () {
+    let data = {
+      'hours': [5, 6, 2, 8, 4, 3],
+      'worker': ["david", "david", "john", "alice", "john", "david"],
+      'day': ["monday", "tuesday", "wednesday", "thursday", "friday", "friday"]
+    };
+    let df = new dfd.DataFrame(data);
+    let group_df = df.groupby(["worker"]);
+    let rslt = [
+      ["david", 3, 3],
+      ["john", 2, 2],
+      ["alice", 1, 1]
+    ];
+    assert.deepEqual(group_df.count().values, rslt);
+  });
 });

--- a/src/danfojs-node/test/aggregators/groupby.test.ts
+++ b/src/danfojs-node/test/aggregators/groupby.test.ts
@@ -364,4 +364,20 @@ describe("groupby", function () {
         ]
         assert.deepEqual(group_df.size().values, rslt);
     });
+
+    it("issue 396: fix groupby when first column is int", function () {
+        let data = {
+            'hours': [5, 6, 2, 8, 4, 3],
+            'worker': ["david", "david", "john", "alice", "john", "david"],
+            'day': ["monday", "tuesday", "wednesday", "thursday", "friday", "friday"]
+        };
+        let df = new DataFrame(data);
+        let group_df = df.groupby(["worker"]);
+        let rslt = [
+            ["david", 3, 3],
+            ["john", 2, 2],
+            ["alice", 1, 1]
+        ];
+        assert.deepEqual(group_df.count().values, rslt);
+    });
 })


### PR DESCRIPTION
- [x] Write test that would fail in `src/danfojs-browser/tests/aggregators/groupby.test.js`
- [x] Write test that would fail in `src/danfojs-node/test/aggregators/groupby.test.ts`
- [x] Modify `src/danfojs-base/aggregators/groupby.ts` and `src/danfojs-base/core/frame.ts` to fix the issue
- [x] Run the tests again and check that the tests passed

Feel free to modify the code or add comments with the changes if you think something could be improved.

Thanks!