### PR TITLE
feat: Added diff() function to DataFrame

### DIFF
--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -1334,6 +1334,106 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
     }
 
     /**
+     * Return difference of DataFrame with other.
+     * @param other DataFrame, Series, Array or Scalar number (positive numbers are preceding rows, negative are following rows) to compare difference with.
+     * @param options.axis 0 or 1. If 0, compute the difference column-wise, if 1, row-wise
+     * @param options.inplace Boolean indicating whether to perform the operation inplace or not. Defaults to false
+     * @example
+     * ```
+     * const df = new DataFrame([[1, 2, 3, 4, 5, 6], [1, 1, 2, 3, 5, 8], [1, 4, 9, 16, 25, 36]], { columns: ['A', 'B', 'C'] })
+     * 
+     * // Difference with previous row
+     * const df0 = df.diff(1)
+     * console.log(df0)
+     * 
+     * // Difference with previous column
+     * const df1 = df.diff(1, {axis: 0})
+     * console.log(df1)
+     * 
+     * // Difference with previous 3rd previous row
+     * const df2 = df.diff(3)
+     * console.log(df2)
+     * 
+     * // Difference with following row
+     * const df3 = df.diff(-1)
+     * console.log(df3)
+     * 
+     * // Difference with another DataFrame
+     * const df4 = df.diff(df3)
+     * console.log(df4)
+     * ```
+    */
+    diff(other: DataFrame | Series | number[] | number, options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame
+    diff(other: DataFrame | Series | number[] | number, options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame | void {
+        const { inplace, axis } = { inplace: false, axis: 1, ...options }
+
+        if (this.$frameIsNotCompactibleForArithmeticOperation()) {
+            throw Error("TypeError: diff operation is not supported for string dtypes");
+        }
+
+        if ([0, 1].indexOf(axis) === -1) {
+            throw Error("ParamError: Axis must be 0 or 1");
+        }
+
+        if (other === 0) {
+            return this;
+        }
+
+        if (typeof other === "number" && axis === 1) {
+            const orig_tensor = this.tensor.clone();
+            let unit = [NaN];
+            for (let i = 1; i < orig_tensor.shape[orig_tensor.rank - 1]; i++) {
+                unit.push(NaN);
+            }
+            let diff_array: any[] = orig_tensor.arraySync();
+            if (other > 0) {
+                for (let i = 0; i < other; i++) {
+                    diff_array.unshift(unit);
+                    diff_array.pop();
+                }
+            }
+            else if (other < 0) {
+                for (let i = 0; i > other; i--) {
+                    diff_array.push(unit);
+                    diff_array.shift();
+                }
+            }
+            const diff_tensor = tensorflow.tensor2d(diff_array, orig_tensor.shape);
+            return this.$MathOps([orig_tensor, diff_tensor], "sub", inplace);
+        }
+
+        if (typeof other === "number" && axis === 0) {
+            const orig_df = new DataFrame(this.tensor.clone());
+            const orig_tensor = orig_df.T.tensor.clone();
+            let unit = [NaN];
+            for (let i = 1; i < orig_tensor.shape[orig_tensor.rank - 1]; i++) {
+                unit.push(NaN);
+            }
+            let diff_array: any[] = orig_tensor.arraySync();
+            if (other > 0) {
+                for (let i = 0; i < other; i++) {
+                    diff_array.unshift(unit);
+                    diff_array.pop();
+                }
+            }
+            else if (other < 0) {
+                for (let i = 0; i > other; i--) {
+                    diff_array.push(unit);
+                    diff_array.shift();
+                }
+            }
+            const diff_tensor = tensorflow.tensor2d(diff_array, orig_tensor.shape);
+            const diff_df = this.$MathOps([orig_tensor, diff_tensor], "sub", inplace) as DataFrame;
+            return diff_df.T;
+        }
+
+        if (other instanceof DataFrame || other instanceof Series) {
+            const tensors = this.$getTensorsForArithmeticOperationByAxis(other, axis);
+            return this.$MathOps(tensors, "sub", inplace);
+        }
+    }
+
+    /**
      * Return the absolute value of elements in a DataFrame. 
      * @param options.inplace Boolean indicating whether to perform the operation inplace or not. Defaults to false
      * @example

--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -1379,29 +1379,12 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
             return this;
         }
 
-        if (typeof other === "number" && axis === 1) {
-            const originalTensor = this.tensor.clone();
-            const unit = new Array(originalTensor.shape[originalTensor.rank - 1]).fill(NaN);
-            let diffArray: any[] = originalTensor.arraySync();
-            if (other > 0) {
-                for (let i = 0; i < other; i++) {
-                    diffArray.unshift(unit);
-                    diffArray.pop();
-                }
+        if (typeof other === "number") {
+            let origDF = this.copy() as DataFrame;
+            if (axis === 0) {
+                origDF = origDF.T;
             }
-            else if (other < 0) {
-                for (let i = 0; i > other; i--) {
-                    diffArray.push(unit);
-                    diffArray.shift();
-                }
-            }
-            const diffTensor = tensorflow.tensor2d(diffArray, originalTensor.shape);
-            return this.$MathOps([originalTensor, diffTensor], "sub", inplace);
-        }
-
-        if (typeof other === "number" && axis === 0) {
-            const origDF = this.copy() as DataFrame;
-            const originalTensor = origDF.T.tensor.clone();
+            const originalTensor = origDF.tensor.clone();
             const unit = new Array(originalTensor.shape[originalTensor.rank - 1]).fill(NaN);
             let diffArray: any[] = originalTensor.arraySync();
             if (other > 0) {
@@ -1418,7 +1401,10 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
             }
             const diffTensor = tensorflow.tensor2d(diffArray, originalTensor.shape);
             const diffDF = this.$MathOps([originalTensor, diffTensor], "sub", inplace) as DataFrame;
-            return diffDF.T;
+            if (axis === 0) {
+                return diffDF.T;
+            }
+            return diffDF;
         }
 
         if (other instanceof DataFrame || other instanceof Series) {

--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -1380,51 +1380,45 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
         }
 
         if (typeof other === "number" && axis === 1) {
-            const orig_tensor = this.tensor.clone();
-            let unit = [NaN];
-            for (let i = 1; i < orig_tensor.shape[orig_tensor.rank - 1]; i++) {
-                unit.push(NaN);
-            }
-            let diff_array: any[] = orig_tensor.arraySync();
+            const originalTensor = this.tensor.clone();
+            const unit = new Array(originalTensor.shape[originalTensor.rank - 1]).fill(NaN);
+            let diffArray: any[] = originalTensor.arraySync();
             if (other > 0) {
                 for (let i = 0; i < other; i++) {
-                    diff_array.unshift(unit);
-                    diff_array.pop();
+                    diffArray.unshift(unit);
+                    diffArray.pop();
                 }
             }
             else if (other < 0) {
                 for (let i = 0; i > other; i--) {
-                    diff_array.push(unit);
-                    diff_array.shift();
+                    diffArray.push(unit);
+                    diffArray.shift();
                 }
             }
-            const diff_tensor = tensorflow.tensor2d(diff_array, orig_tensor.shape);
-            return this.$MathOps([orig_tensor, diff_tensor], "sub", inplace);
+            const diffTensor = tensorflow.tensor2d(diffArray, originalTensor.shape);
+            return this.$MathOps([originalTensor, diffTensor], "sub", inplace);
         }
 
         if (typeof other === "number" && axis === 0) {
-            const orig_df = new DataFrame(this.tensor.clone());
-            const orig_tensor = orig_df.T.tensor.clone();
-            let unit = [NaN];
-            for (let i = 1; i < orig_tensor.shape[orig_tensor.rank - 1]; i++) {
-                unit.push(NaN);
-            }
-            let diff_array: any[] = orig_tensor.arraySync();
+            const origDF = this.copy() as DataFrame;
+            const originalTensor = origDF.T.tensor.clone();
+            const unit = new Array(originalTensor.shape[originalTensor.rank - 1]).fill(NaN);
+            let diffArray: any[] = originalTensor.arraySync();
             if (other > 0) {
                 for (let i = 0; i < other; i++) {
-                    diff_array.unshift(unit);
-                    diff_array.pop();
+                    diffArray.unshift(unit);
+                    diffArray.pop();
                 }
             }
             else if (other < 0) {
                 for (let i = 0; i > other; i--) {
-                    diff_array.push(unit);
-                    diff_array.shift();
+                    diffArray.push(unit);
+                    diffArray.shift();
                 }
             }
-            const diff_tensor = tensorflow.tensor2d(diff_array, orig_tensor.shape);
-            const diff_df = this.$MathOps([orig_tensor, diff_tensor], "sub", inplace) as DataFrame;
-            return diff_df.T;
+            const diffTensor = tensorflow.tensor2d(diffArray, originalTensor.shape);
+            const diffDF = this.$MathOps([originalTensor, diffTensor], "sub", inplace) as DataFrame;
+            return diffDF.T;
         }
 
         if (other instanceof DataFrame || other instanceof Series) {

--- a/src/danfojs-base/shared/types.ts
+++ b/src/danfojs-base/shared/types.ts
@@ -184,8 +184,8 @@ export interface SeriesInterface extends NDframeInterface {
     toCSV(options?: CsvOutputOptionsBrowser): string | void
     toJSON(options?: JsonOutputOptionsBrowser): object | void
     toExcel(options?: ExcelOutputOptionsBrowser): void
-    iat(index: number): number | string | boolean | undefined 
-    at(index: string | number): number | string | boolean | undefined 
+    iat(index: number): number | string | boolean | undefined
+    at(index: string | number): number | string | boolean | undefined
 }
 
 //Start of DataFrame class types
@@ -218,6 +218,7 @@ export interface DataFrameInterface extends NDframeInterface {
     div(other: DataFrame | Series | number | number[], options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame | void
     pow(other: DataFrame | Series | number | number[], options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame | void
     mod(other: DataFrame | Series | number | number[], options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame | void
+    diff(other: DataFrame | Series | number[] | number, options?: { axis?: 0 | 1, inplace?: boolean }): DataFrame | void
     mean(options?: { axis?: 0 | 1 }): Series
     median(options?: { axis?: 0 | 1 }): Series
     mode(options?: { axis?: 0 | 1, keep?: number }): Series
@@ -329,8 +330,8 @@ export interface DataFrameInterface extends NDframeInterface {
     toCSV(options?: CsvOutputOptionsBrowser): string | void
     toJSON(options?: JsonOutputOptionsBrowser): object | void
     toExcel(options?: ExcelOutputOptionsBrowser): void
-    iat(row: number, column: number): number | string | boolean | undefined 
-    at(row: string | number, column: string): number | string | boolean | undefined 
+    iat(row: number, column: number): number | string | boolean | undefined
+    at(row: string | number, column: string): number | string | boolean | undefined
 }
 
 export interface DateTime {

--- a/src/danfojs-browser/tests/core/frame.test.js
+++ b/src/danfojs-browser/tests/core/frame.test.js
@@ -101,7 +101,7 @@ describe("DataFrame", function () {
       assert.deepEqual(df.dtypes, [ "string", "int32", "float32", "string" ]);
       assert.deepEqual(df.index, [ 0, 1, 2, 3 ]);
     });
-    it("Add new dfd.Series to DataFrame works", function () {
+    it("Add new Series to DataFrame works", function () {
       let data = { alpha: [ "A", "B", "C", "D" ], count: [ 1, 2, 3, 4 ], sum: [ 20.3, 30.456, 40.90, 90.1 ] };
       let df = new dfd.DataFrame(data);
       const newdf = df.addColumn("new_column", new dfd.Series([ "a", "b", "c", "d" ]));

--- a/src/danfojs-browser/tests/core/frame.test.js
+++ b/src/danfojs-browser/tests/core/frame.test.js
@@ -101,7 +101,7 @@ describe("DataFrame", function () {
       assert.deepEqual(df.dtypes, [ "string", "int32", "float32", "string" ]);
       assert.deepEqual(df.index, [ 0, 1, 2, 3 ]);
     });
-    it("Add new Series to DataFrame works", function () {
+    it("Add new dfd.Series to DataFrame works", function () {
       let data = { alpha: [ "A", "B", "C", "D" ], count: [ 1, 2, 3, 4 ], sum: [ 20.3, 30.456, 40.90, 90.1 ] };
       let df = new dfd.DataFrame(data);
       const newdf = df.addColumn("new_column", new dfd.Series([ "a", "b", "c", "d" ]));
@@ -1016,6 +1016,51 @@ describe("DataFrame", function () {
       assert.deepEqual(df1.mod(df2).values, [ [ 0, 0, 0 ], [ 0, 0, NaN ] ]);
     });
 
+  });
+
+  describe("diff", function () {
+    it("Return same DataFrame if other === 0", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(0)).values, [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ]);
+    });
+    it("Return difference of DataFrame with previous row", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(1)).values, [ [ NaN, NaN, NaN ], [ 10, 8, 6 ], [ -9, -8, -7 ] ]);
+    });
+    it("Return difference of DataFrame with following row", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(-1)).values, [ [ -10, -8, -6 ], [ 9, 8, 7 ], [ NaN, NaN, NaN ] ]);
+    });
+    it("Return difference of a DataFrame with a Series along default axis 1", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const sf = new dfd.Series([ 1, 2, 1 ]);
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(sf)).values, [ [ -1, 0, 3 ], [ 9, 8, 9 ], [ 0, 0, 2 ] ]);
+    });
+    it("Return difference of a DataFrame with along axis 0 (column-wise), previous column", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(1, { axis: 0 })).values, [ [ NaN, 2, 2 ], [ NaN, 0, 0 ], [ NaN, 1, 1 ] ]);
+    });
+    it("Return difference of a DataFrame with along axis 0 (column-wise), following column", function () {
+      const data = [ [ 0, 2, 4 ], [ 10, 10, 10 ], [ 1, 2, 3 ] ];
+      const df = new dfd.DataFrame(data);
+      assert.deepEqual((df.diff(-1, { axis: 0 })).values, [ [ -2, -2, NaN ], [ 0, 0, NaN ], [ -1, -1, NaN ] ]);
+    });
+    it("Return difference of a DataFrame with another DataFrame along default axis 1", function () {
+      const df1 = new dfd.DataFrame([ [ 0, 2, 4 ], [ 3, 10, 4 ] ]);
+      const df2 = new dfd.DataFrame([ [ -1, -2, 4 ], [ 10, 5, 0 ] ]);
+      assert.deepEqual((df1.diff(df2)).values, [ [ 1, 4, 0 ], [ -7, 5, 4 ] ]);
+    });
+    it("Throw error if DataFrame for diff contains string", function () {
+      const df = new dfd.DataFrame([ [ "words", "words", "words" ], [ "words", "words", "words" ] ]);
+      assert.throws(() => {
+        df.diff(1);
+      }, Error, "TypeError: diff operation is not supported for string dtypes");
+    });
   });
 
   describe("mean", function () {

--- a/src/danfojs-node/test/core/frame.test.ts
+++ b/src/danfojs-node/test/core/frame.test.ts
@@ -993,6 +993,11 @@ describe("DataFrame", function () {
     });
 
     describe("diff", function () {
+        it("Return same DataFrame if other === 0", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(0) as DataFrame).values, [[0, 2, 4], [10, 10, 10], [1, 2, 3]]);
+        });
         it("Return difference of DataFrame with previous row", function () {
             const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
             const df = new DataFrame(data);
@@ -1001,7 +1006,7 @@ describe("DataFrame", function () {
         it("Return difference of DataFrame with following row", function () {
             const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
             const df = new DataFrame(data);
-            assert.deepEqual((df.diff(-1) as DataFrame).values, [[-2, 0, 2], [8, 8, 8], [-1, 0, 1]]);
+            assert.deepEqual((df.diff(-1) as DataFrame).values, [[-10, -8, -6], [9, 8, 7], [NaN, NaN, NaN]]);
         });
         it("Return difference of a DataFrame with a Series along default axis 1", function () {
             const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
@@ -1017,17 +1022,18 @@ describe("DataFrame", function () {
         it("Return difference of a DataFrame with along axis 0 (column-wise), following column", function () {
             const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
             const df = new DataFrame(data);
-            assert.deepEqual((df.diff(1, { axis: 0 }) as DataFrame).values, [[-2, 2, NaN], [0, 0, NaN], [1, 1, NaN]]);
+            assert.deepEqual((df.diff(-1, { axis: 0 }) as DataFrame).values, [[-2, -2, NaN], [0, 0, NaN], [-1, -1, NaN]]);
         });
         it("Return difference of a DataFrame with another DataFrame along default axis 1", function () {
             const df1 = new DataFrame([[0, 2, 4], [3, 10, 4]]);
-            const df2 = new DataFrame([[1, 2, 4], [10, 5, 0]]);
-            assert.deepEqual((df1.diff(df2) as DataFrame).values, [[-1, 0, 0], [-7, 5, 4]]);
+            const df2 = new DataFrame([[-1, -2, 4], [10, 5, 0]]);
+            assert.deepEqual((df1.diff(df2) as DataFrame).values, [[1, 4, 0], [-7, 5, 4]]);
         });
-        it("Return difference of a DataFrame with another DataFrame along axis 0", function () {
-            const df1 = new DataFrame([[0, 2, 4], [3, 10, 4]]);
-            const df2 = new DataFrame([[1, 2, 4], [10, 5, 0]]);
-            assert.deepEqual((df1.diff(df2, { axis: 0 }) as DataFrame).values, [[-1, 0, 0], [-7, 5, 4]]);
+        it("Throw error if DataFrame for diff contains string", function () {
+            const df = new DataFrame([["words", "words", "words"], ["words", "words", "words"]]);
+            assert.throws(() => {
+                df.diff(1);
+            }, Error, "TypeError: diff operation is not supported for string dtypes");
         });
     });
 

--- a/src/danfojs-node/test/core/frame.test.ts
+++ b/src/danfojs-node/test/core/frame.test.ts
@@ -992,6 +992,45 @@ describe("DataFrame", function () {
 
     });
 
+    describe("diff", function () {
+        it("Return difference of DataFrame with previous row", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(1) as DataFrame).values, [[NaN, NaN, NaN], [10, 8, 6], [-9, -8, -7]]);
+        });
+        it("Return difference of DataFrame with following row", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(-1) as DataFrame).values, [[-2, 0, 2], [8, 8, 8], [-1, 0, 1]]);
+        });
+        it("Return difference of a DataFrame with a Series along default axis 1", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const sf = new Series([1, 2, 1]);
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(sf) as DataFrame).values, [[-1, 0, 3], [9, 8, 9], [0, 0, 2]]);
+        });
+        it("Return difference of a DataFrame with along axis 0 (column-wise), previous column", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(1, { axis: 0 }) as DataFrame).values, [[NaN, 2, 2], [NaN, 0, 0], [NaN, 1, 1]]);
+        });
+        it("Return difference of a DataFrame with along axis 0 (column-wise), following column", function () {
+            const data = [[0, 2, 4], [10, 10, 10], [1, 2, 3]];
+            const df = new DataFrame(data);
+            assert.deepEqual((df.diff(1, { axis: 0 }) as DataFrame).values, [[-2, 2, NaN], [0, 0, NaN], [1, 1, NaN]]);
+        });
+        it("Return difference of a DataFrame with another DataFrame along default axis 1", function () {
+            const df1 = new DataFrame([[0, 2, 4], [3, 10, 4]]);
+            const df2 = new DataFrame([[1, 2, 4], [10, 5, 0]]);
+            assert.deepEqual((df1.diff(df2) as DataFrame).values, [[-1, 0, 0], [-7, 5, 4]]);
+        });
+        it("Return difference of a DataFrame with another DataFrame along axis 0", function () {
+            const df1 = new DataFrame([[0, 2, 4], [3, 10, 4]]);
+            const df2 = new DataFrame([[1, 2, 4], [10, 5, 0]]);
+            assert.deepEqual((df1.diff(df2, { axis: 0 }) as DataFrame).values, [[-1, 0, 0], [-7, 5, 4]]);
+        });
+    });
+
     describe("mod", function () {
         it("Return modulus of DataFrame with a single Number", function () {
             const data = [[0, 2, 4], [360, 180, 360]];


### PR DESCRIPTION
Added a diff() function to mimic the functionality of the equivalent function in pandas as best as possible.

Can calculate difference between rows and columns both forwards and backwards, in addition to difference in relation to another dataframe or series.

Added the function to the DataFrame interface.

Added unit testing with as much coverage as I could. The error that is thrown if the axis is set as something other than 0 or 1 follows the convension from a similar function, but as far as I can tell TypeScript won't let you set axis to anything besides 0 or 1, so it is untestable.

The implementation is made using the built in tensorflow functionality for pretty much everything except nudging the data to compare, and I believe this is one of the faster ways to achieve this!