### PR TITLE
fix: fillNa throws an error when values is an empty string

### DIFF
--- a/src/danfojs-base/core/frame.ts
+++ b/src/danfojs-base/core/frame.ts
@@ -2102,7 +2102,7 @@ export default class DataFrame extends NDframe implements DataFrameInterface {
     ): DataFrame | void {
         let { columns, inplace } = { inplace: false, ...options }
 
-        if (!values && typeof values !== "boolean" && typeof values !== "number") {
+        if (!values && typeof values !== "boolean" && typeof values !== "number" && typeof values !== "string") {
             throw Error('ParamError: value must be specified');
         }
 


### PR DESCRIPTION
Dataframe.fillNa("") throws an error. 
There are few use cases when we want to fill NaN with an empty string.
This feature is supported by pandas.