### PR TITLE
Fix for readCSV mismatch between Browser and Node

### DIFF
--- a/src/danfojs-base/io/browser/io.csv.ts
+++ b/src/danfojs-base/io/browser/io.csv.ts
@@ -52,6 +52,7 @@ const $readCSV = async (file: any, options?: CsvInputOptionsBrowser): Promise<Da
     Papa.parse(file, {
       header: true,
       dynamicTyping: true,
+      skipEmptyLines: 'greedy',
       ...options,
       download: true,
       complete: results => {

--- a/src/danfojs-base/io/node/io.csv.ts
+++ b/src/danfojs-base/io/node/io.csv.ts
@@ -55,6 +55,7 @@ const $readCSV = async (filePath: string, options?: CsvInputOptionsNode): Promis
       const optionsWithDefaults = {
         header: true,
         dynamicTyping: true,
+        skipEmptyLines: 'greedy',
         ...options,
       }
 

--- a/src/danfojs-base/io/node/io.csv.ts
+++ b/src/danfojs-base/io/node/io.csv.ts
@@ -60,7 +60,7 @@ const $readCSV = async (filePath: string, options?: CsvInputOptionsNode): Promis
       }
 
       const dataStream = request.get(filePath);
-      const parseStream: any = Papa.parse(Papa.NODE_STREAM_INPUT, optionsWithDefaults);
+      const parseStream: any = Papa.parse(Papa.NODE_STREAM_INPUT, optionsWithDefaults as any);
       dataStream.pipe(parseStream);
 
       const data: any = [];


### PR DESCRIPTION
There is a mismatch between the readCSV calls for Browser and Web. I have a CSV located at https://scikitjs.org/data/boston.csv, which has 506 rows (it's a famous Boston housing dataset). When I read it with danfojs-node with the following code

```js
let dfd = require("danfojs-node")
dfd.readCSV("https://scikitjs.org/data/boston.csv").then((df) => console.log(df.shape))
```

it correctly tells me that I have 506 rows, and 14 columns. But when I do the same thing with the browser build, example index.html file as follows.

```html
<!DOCTYPE html>
<html>
  <body>
    Open console to see result.
    <div>We print the shape of the Boston csv located <a href="https://scikitjs.org/data/boston.csv">here</a></div>
    <br />
    <div>
      This CSV has 506 rows and 14 columns, but the web version thinks that it has 507 rows because it thinks there's an empty line
      at the end of the file and adds that to the dataframe. The node version doesn't do that. An easy solution is to just pass <pre>{skipEmptyLines: "greedy"}</pre> 
      to Papaparse and it will filter this erroneous row out.
    </div>    
    <script src="https://cdn.jsdelivr.net/npm/danfojs@1.1.0/lib/bundle.js"></script>
    <script>
      dfd.readCSV("https://scikitjs.org/data/boston.csv").then((df) => {
        console.log(`The shape of the fetched boston dataset is [${df.shape}] but it should be [506,14]`)
      })
    </script>
  </body>
</html>
```

then it says there are 507 rows. After some digging it looks like the dfd.readCSV has an extra "empty" line at the end of the dataframe. An easy fix for this is just to set another default parameter to the Papaparse config options `skipEmptyLines: greedy`. The docs for that option are here https://www.papaparse.com/docs and I think it would be a good addition to the default options that we pass to Papaparse. 