### PR TITLE
Allow Series.append() to use zero, fixes #486

### DIFF
--- a/src/danfojs-base/core/series.ts
+++ b/src/danfojs-base/core/series.ts
@@ -1855,8 +1855,8 @@ export default class Series extends NDframe implements SeriesInterface {
     ): Series | void {
         const { inplace } = { inplace: false, ...options }
 
-        if (!newValue && typeof newValue !== "boolean") {
-            throw Error("Param Error: newValues cannot be null or undefined");
+        if (!newValue && typeof newValue !== "boolean" && typeof newValue !== "number") {
+            throw Error("Param Error: newValue cannot be null or undefined");
         }
 
         if (!index) {

--- a/src/danfojs-browser/tests/core/series.test.js
+++ b/src/danfojs-browser/tests/core/series.test.js
@@ -1491,6 +1491,13 @@ describe("Series Functions", () => {
       sf1.append(sf2, index, { inplace: true });
       assert.deepEqual(sf1.index, [ 0, 1, 2, 3, 4, 5, 6 ]);
     });
+    it("Can append a value of zero", function() {
+      const data = [ 1, 2, 3, 4, "a", "b", "c" ];
+      const sf = new dfd.Series(data);
+      const expected_val = [ 1, 2, 3, 4, "a", "b", "c", 0 ];
+      sf.append(0, 7, { inplace: true });
+      assert.deepEqual(sf.values, expected_val);
+    });
   });
 
   describe("and", function () {

--- a/src/danfojs-node/test/core/series.test.ts
+++ b/src/danfojs-node/test/core/series.test.ts
@@ -1492,6 +1492,13 @@ describe("Series Functions", () => {
             sf1.append(sf2, index, { inplace: true });
             assert.deepEqual(sf1.index, [0, 1, 2, 3, 4, 5, 6]);
         });
+        it("Can append a value of zero", function() {
+            const data = [1, 2, 3, 4, "a", "b", "c"];
+            const sf = new Series(data);
+            const expected_val = [1, 2, 3, 4, "a", "b", "c", 0];
+            sf.append(0, 7, { inplace: true });
+            assert.deepEqual(sf.values, expected_val);
+        })
     });
 
     describe("and", function () {


### PR DESCRIPTION
This fixes #486 that I filed the other day. It allows Series.append() to handle a zero literal as an input.

Also includes tests for both node and browser environments.