### PR TITLE
Fix `webpack.config.js` to match `package.json`

### DIFF
--- a/src/danfojs-browser/webpack.config.js
+++ b/src/danfojs-browser/webpack.config.js
@@ -12,7 +12,7 @@ const createConfig = () => {
     target: "web",
     output: {
       path: path.resolve(__dirname, "lib"),
-      filename: "bundle.js",
+      filename: "bundle-esm.js",
       library: "dfd"
     },
     module: {


### PR DESCRIPTION
Fixes #514 

The problem is that two different file names are used, `bundle.js` and `bundle-esm.js` https://github.com/javascriptdata/danfojs/blob/fe37f10c83265e22a645e9921e0d880b9b75a180/src/danfojs-browser/package.json#L7 https://github.com/javascriptdata/danfojs/blob/a8d14d45bca2a50836a6e2d6ec1a77582c42993a/src/danfojs-browser/webpack.config.js#L15

This is the breaking change
https://github.com/javascriptdata/danfojs/pull/447/files