### PR TITLE
fix: fix for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     ],
     "scripts": {
         "install": "cd src/danfojs-base && yarn && cd ../danfojs-browser && yarn && cd ../danfojs-node && yarn",
-        "build": "cd src/danfojs-node && yarn build:clean && cd ../danfojs-browser && yarn build:clean",
-        "test": "cd src/danfojs-base && yarn && cd ../danfojs-node && yarn && yarn test:clean && cd ../danfojs-browser && yarn && yarn test:clean"
+        "build": "yarn build:browser && yarn build:node",
+        "build:browser": "cd src/danfojs-browser && yarn build:clean",
+        "build:node": "cd src/danfojs-node && yarn build:clean",
+        "pretest": "cd src/danfojs-base && yarn",
+        "test": "yarn test:browser && yarn test:node",
+        "pretest:browser": "yarn pretest",
+        "test:browser": "cd src/danfojs-browser && yarn && yarn test:clean",
+        "pretest:node": "yarn pretest",
+        "test:node": "cd src/danfojs-node && yarn && yarn test:clean"
     }
 }

--- a/src/danfojs-browser/package.json
+++ b/src/danfojs-browser/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript library providing high performance, intuitive, and easy to use data structures for manipulating and processing structured data.",
   "main": "dist/danfojs-browser/src/index.js",
   "types": "dist/danfojs-browser/src/index.d.ts",
-  "module": "lib/bundle-esm.js",
+  "module": "lib/bundle.js",
   "directories": {
     "test": "tests"
   },

--- a/src/danfojs-browser/webpack.config.js
+++ b/src/danfojs-browser/webpack.config.js
@@ -12,7 +12,7 @@ const createConfig = () => {
     target: "web",
     output: {
       path: path.resolve(__dirname, "lib"),
-      filename: "bundle-esm.js",
+      filename: "bundle.js",
       library: "dfd"
     },
     module: {


### PR DESCRIPTION
Browser tests are filing as the bundle file Karma tries to load is not found and frontend tests fail to even start.

It looks like the issue was introduced by #516 and I'm not sure what it aimed to solve since the esbuild generated file is bundle.esm.js, whilst the webpack one was bundle-esm.js (simply bundle.js with this PR.)

I think the file rename was unnecessary, so I've reverted that.

We could also update the karma configuration file to use bundle-esm.js, it fixes the browser tests as well.

