### PR TITLE
fix empty new DataFrame({ series: [] }) handling with automatic index calculation

### DIFF
--- a/src/danfojs-base/core/generic.ts
+++ b/src/danfojs-base/core/generic.ts
@@ -285,7 +285,7 @@ export default class NDframe implements NDframeInterface {
 
             this.$index = index
         } else {
-            this.$index = utils.range(0, this.shape[0] - 1) //generate index
+            this.$index = utils.erange(0, this.shape[0]) //generate index
         }
     }
 
@@ -293,7 +293,7 @@ export default class NDframe implements NDframeInterface {
      * Internal function to reset the index of the NDFrame using a range of indices.
     */
     $resetIndex(): void {
-        this.$index = utils.range(0, this.shape[0] - 1)
+        this.$index = utils.erange(0, this.shape[0])
     }
 
     /**
@@ -333,7 +333,7 @@ export default class NDframe implements NDframeInterface {
 
                 this.$columns = columns
             } else {
-                this.$columns = (utils.range(0, this.shape[1] - 1)).map((val) => `${val}`) //generate columns
+                this.$columns = (utils.erange(0, this.shape[1])).map((val) => `${val}`) //generate columns
             }
         }
     }

--- a/src/danfojs-base/shared/utils.ts
+++ b/src/danfojs-base/shared/utils.ts
@@ -125,6 +125,19 @@ export default class Utils {
     }
 
     /**
+     * Generates an array of integers between specified range with exclusive end
+     * @param start The starting number.
+     * @param end The exclusive end number.
+     */
+    erange(start: number, end: number): Array<number> {
+         const arr = [];
+         for (let i = start; i < end; i++) {
+             arr.push(i);
+         }
+         return arr;
+     }
+
+    /**
      * Checks if object has the specified key
      * @param obj The object to check.
      * @param key The key to find.


### PR DESCRIPTION
the range check in utils.range fails when constructing a dataframe where the columns are of 0 length for the automatically calculated default index.  Perfectly valid and otherwise working but requires index to be specified every time.  This PR adds a trivial fix for it.

I could not figure out how to build danfo as a npmjs.org compatible package - could use some tips there.